### PR TITLE
Speed up combvec

### DIFF
--- a/src/grids.jl
+++ b/src/grids.jl
@@ -156,16 +156,9 @@ Counterpart of Matlab's combvec:
 Creates all combinations of vectors in `vecs`, an array of vectors.
 """
 function combvec(vecs::Vector{Vector{T}}) where T
-	D = length(vecs)
-	N = map(length, vecs) |> prod
-	y = [Vector{T}(undef, D) for _ in 1:N]
-
-	# Construct all Cartesian combinations of elements in vec as tuples
+	# Construct all Cartesian combinations of elements in vecs
 	P = Iterators.product(vecs...)
-	for (n, p) in enumerate(P)
-		y[n] = [p...]
-	end
-
+	y = collect.(vec(collect(P)))
 	return y
 end
 


### PR DESCRIPTION
Removing the splats and redundant allocations in `combvec` yields a nice speedup:

```julia
julia> @btime sparsegrid(8,10);
  5.149 s (57567723 allocations: 3.67 GiB)

julia> @btime sparsegrid(8,10);
  2.728 s (4718478 allocations: 965.12 MiB)
```

All tests passed.