### PR TITLE
Scale nodes to hyper-rectangle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseGrids"
 uuid = "bafbe729-afc6-5148-bb4f-226bf3d46895"
 authors = ["Robert DJ <git@dahl-jacobsen.dk>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
@@ -10,7 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "1.5"
-FastGaussQuadrature = "0.4, 0.5"
+FastGaussQuadrature = "1.0"
 IterTools = "1.3"
 
 [extras]

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -34,6 +34,39 @@ function sparsegrid(D::Integer, order::Integer, f::Function=gausshermite; sym::B
 	return nodes, weights
 end
 
+function sparsegrid(D::Integer, order::Integer, lb::Array{Float64,1}, ub::Array{Float64,1}, f::Function=gausschebyshevt; sym::Bool=true)
+
+	if length(lb) != D || length(ub) != D
+		error("Either 'lb' or 'ub' have incorrect length.")
+	end
+	# Final nodes and weights in D dimensions
+	nodes = Array{Float64}(undef, D, 0)
+	weights = Array{Float64}(undef, 0)
+
+	# Compute univariate nodes and weights
+	nodes1D = Vector{Vector{Float64}}(undef, order)
+	weights1D = similar(nodes1D)
+
+	for k in 1:order
+		nodes1D[k], weights1D[k] = f(k)
+
+		if sym
+			symmetrize!(nodes1D[k])
+		end
+	end
+
+	nodes, weights = sparsegrid(D, nodes1D, weights1D)
+
+	for i in eachindex(nodes)
+
+		for j in eachindex(nodes[i])
+		    nodes[i][j] = 0.5 * (lb[j] + ub[j]) + 0.5 * (ub[j] - lb[j]) * nodes[i][j]
+		end
+
+	end
+
+	return nodes, weights
+end
 
 # Computation of sparse grid nodes and the associated weights
 # from collection of one-dimensional nodes and weights


### PR DESCRIPTION
Introduces a new method for sparsegrid() that produces points scaled to a supplied hyper-rectangle.  By default the (un-scaled) points are computed using gausschebyshevt() from FastGaussQuadrature.jl.  Also, bumps the compatability on FastGaussQuadrature to 1.0.